### PR TITLE
Fix userinfo command on passing a user id

### DIFF
--- a/userinfo.py
+++ b/userinfo.py
@@ -63,7 +63,7 @@ class UserInfoMod(loader.Module):
             if not args:
                 return await utils.answer(message, self.strings("no_args_or_reply", message))
             try:
-                full = await self.client(GetFullUserRequest(args[0]))
+                full = await self.client(GetFullUserRequest(int(args[0])))
             except ValueError:
                 return await utils.answer(message, self.strings("find_error", message))
         logger.debug(full)


### PR DESCRIPTION
I guess args accepts a string and on passing user id with .userinfo command it throws ValueError("Couldn't find that user.")